### PR TITLE
Fix pagination and filters together

### DIFF
--- a/src/mixemy/repositories/_base/_audit.py
+++ b/src/mixemy/repositories/_base/_audit.py
@@ -4,26 +4,24 @@ from typing import Any, override
 from sqlalchemy import Select, asc, desc
 
 from mixemy.repositories._base._base import BaseRepository
+from mixemy.schemas import InputSchema
 from mixemy.schemas.paginations import AuditPaginationFilter, OrderDirection
 from mixemy.types import (
     AuditModelType,
-    PaginationSchemaType,
 )
 
 
 class AuditRepository(BaseRepository[AuditModelType], ABC):
     @override
-    @staticmethod
     def _add_after_filter(
-        statement: Select[Any], filter: PaginationSchemaType | None
+        self, statement: Select[Any], filters: InputSchema | None
     ) -> Select[Any]:
-        if filter is not None:
-            statement = statement.offset(filter.offset).limit(filter.limit)
-        if isinstance(filter, AuditPaginationFilter):
-            match filter.order_direction:
+        statement = super()._add_after_filter(statement=statement, filters=filters)
+        if isinstance(filters, AuditPaginationFilter):
+            match filters.order_direction:
                 case OrderDirection.ASC:
-                    statement = statement.order_by(asc(filter.order_by))
+                    statement = statement.order_by(asc(filters.order_by))
                 case OrderDirection.DESC:
-                    statement = statement.order_by(desc(filter.order_by))
+                    statement = statement.order_by(desc(filters.order_by))
 
         return statement

--- a/src/mixemy/repositories/_base/_base.py
+++ b/src/mixemy/repositories/_base/_base.py
@@ -1,14 +1,12 @@
 from abc import ABC
 from typing import Any, Generic
 
-from sqlalchemy import Select
+from sqlalchemy import Select, select
 
 from mixemy._exceptions import MixemyRepositorySetupError
 from mixemy.schemas import InputSchema
-from mixemy.types import (
-    BaseModelType,
-    PaginationSchemaType,
-)
+from mixemy.schemas.paginations import PaginationFields, PaginationFilter
+from mixemy.types import BaseModelType
 from mixemy.utils import unpack_schema
 
 
@@ -19,26 +17,40 @@ class BaseRepository(Generic[BaseModelType], ABC):
         self._verify_init()
         self.model = self.model_type
 
-    @staticmethod
     def _add_after_filter(
-        statement: Select[Any], filter: PaginationSchemaType | None
+        self, statement: Select[Any], filters: InputSchema | None
     ) -> Select[Any]:
-        if filter is not None:
-            statement = statement.offset(filter.offset).limit(filter.limit)
+        if isinstance(filters, PaginationFilter):
+            statement = statement.offset(filters.offset).limit(filters.limit)
 
         return statement
 
     def _add_before_filter(
-        self, statement: Select[Any], filter: InputSchema | None
+        self, statement: Select[Any], filters: InputSchema | None
     ) -> Select[Any]:
-        if filter is not None:
-            for item, value in unpack_schema(schema=filter).items():
-                if isinstance(value, list):
-                    statement = statement.where(getattr(self.model, item).in_(value))
-                else:
-                    statement = statement.where(getattr(self.model, item) == value)
+        if filters is not None:
+            for item, value in unpack_schema(
+                schema=filters, exclude=PaginationFields
+            ).items():
+                if hasattr(self.model, item):
+                    if isinstance(value, list):
+                        statement = statement.where(
+                            getattr(self.model, item).in_(value)
+                        )
+                    else:
+                        statement = statement.where(getattr(self.model, item) == value)
 
         return statement
+
+    def _add_filters(
+        self, statement: Select[Any] | None, filters: InputSchema | None
+    ) -> Select[Any]:
+        if statement is None:
+            statement = select(self.model)
+        return self._add_after_filter(
+            statement=self._add_before_filter(statement=statement, filters=filters),
+            filters=filters,
+        )
 
     @staticmethod
     def _update_db_object(db_object: BaseModelType, object_in: InputSchema) -> None:

--- a/src/mixemy/repositories/asyncio/_base.py
+++ b/src/mixemy/repositories/asyncio/_base.py
@@ -9,7 +9,6 @@ from mixemy.repositories._base import BaseRepository
 from mixemy.schemas import InputSchema
 from mixemy.types import (
     BaseModelType,
-    PaginationSchemaType,
 )
 
 
@@ -22,17 +21,11 @@ class BaseAsyncRepository(BaseRepository[BaseModelType], ABC):
     async def read_multi(
         self,
         db_session: AsyncSession,
-        after_filter: PaginationSchemaType | None = None,
-        before_filter: InputSchema | None = None,
+        filters: InputSchema | None = None,
     ) -> Sequence[BaseModelType]:
         return await self._execute_returning_all(
             db_session=db_session,
-            statement=self._add_after_filter(
-                statement=self._add_before_filter(
-                    statement=select(self.model), filter=before_filter
-                ),
-                filter=after_filter,
-            ),
+            statement=self._add_filters(statement=None, filters=filters),
         )
 
     async def update(
@@ -56,7 +49,7 @@ class BaseAsyncRepository(BaseRepository[BaseModelType], ABC):
             db_session=db_session,
             statement=self._add_before_filter(
                 statement=select(func.count()).select_from(self.model),
-                filter=before_filter,
+                filters=before_filter,
             ),
         )
 

--- a/src/mixemy/repositories/sync/_base.py
+++ b/src/mixemy/repositories/sync/_base.py
@@ -9,7 +9,6 @@ from mixemy.repositories._base import BaseRepository
 from mixemy.schemas import InputSchema
 from mixemy.types import (
     BaseModelType,
-    PaginationSchemaType,
 )
 
 
@@ -20,17 +19,11 @@ class BaseSyncRepository(BaseRepository[BaseModelType], ABC):
     def read_multi(
         self,
         db_session: Session,
-        after_filter: PaginationSchemaType | None = None,
-        before_filter: InputSchema | None = None,
+        filters: InputSchema | None = None,
     ) -> Sequence[BaseModelType]:
         return self._execute_returning_all(
             db_session=db_session,
-            statement=self._add_after_filter(
-                statement=self._add_before_filter(
-                    statement=select(self.model), filter=before_filter
-                ),
-                filter=after_filter,
-            ),
+            statement=self._add_filters(statement=None, filters=filters),
         )
 
     def update(
@@ -54,7 +47,7 @@ class BaseSyncRepository(BaseRepository[BaseModelType], ABC):
             db_session=db_session,
             statement=self._add_before_filter(
                 statement=select(func.count()).select_from(self.model),
-                filter=before_filter,
+                filters=before_filter,
             ),
         )
 

--- a/src/mixemy/schemas/paginations/__init__.py
+++ b/src/mixemy/schemas/paginations/__init__.py
@@ -2,4 +2,12 @@ from ._audit import AuditPaginationFilter
 from ._base import PaginationFilter
 from ._order_enums import OrderBy, OrderDirection
 
-__all__ = ["AuditPaginationFilter", "OrderBy", "OrderDirection", "PaginationFilter"]
+PaginationFields = {"limit", "offset", "order_by", "order_direction"}
+
+__all__ = [
+    "AuditPaginationFilter",
+    "OrderBy",
+    "OrderDirection",
+    "PaginationFields",
+    "PaginationFilter",
+]

--- a/src/mixemy/services/asyncio/_base.py
+++ b/src/mixemy/services/asyncio/_base.py
@@ -9,7 +9,6 @@ from mixemy.types import (
     CreateSchemaType,
     FilterSchemaType,
     OutputSchemaType,
-    PaginationSchemaType,
     UpdateSchemaType,
 )
 
@@ -42,13 +41,11 @@ class BaseAsyncService(
     async def read_multi(
         self,
         filters: FilterSchemaType | None = None,
-        pagination: PaginationSchemaType | None = None,
     ) -> list[OutputSchemaType]:
         return [
             self._to_schema(model=model)
             for model in await self.repository.read_multi(
                 db_session=self.db_session,
-                before_filter=filters,
-                after_filter=pagination,
+                filters=filters,
             )
         ]

--- a/src/mixemy/services/sync/_base.py
+++ b/src/mixemy/services/sync/_base.py
@@ -9,7 +9,6 @@ from mixemy.types import (
     CreateSchemaType,
     FilterSchemaType,
     OutputSchemaType,
-    PaginationSchemaType,
     UpdateSchemaType,
 )
 
@@ -42,13 +41,11 @@ class BaseSyncService(
     def read_multi(
         self,
         filters: FilterSchemaType | None = None,
-        pagination: PaginationSchemaType | None = None,
     ) -> list[OutputSchemaType]:
         return [
             self._to_schema(model=model)
             for model in self.repository.read_multi(
                 db_session=self.db_session,
-                before_filter=filters,
-                after_filter=pagination,
+                filters=filters,
             )
         ]

--- a/src/mixemy/utils/_convertors.py
+++ b/src/mixemy/utils/_convertors.py
@@ -7,8 +7,12 @@ TO_MODEL = TypeVar("TO_MODEL", bound=BaseModel)
 TO_SCHEMA = TypeVar("TO_SCHEMA", bound=BaseSchema)
 
 
-def unpack_schema(schema: BaseSchema) -> dict[str, Any]:
-    return schema.model_dump(exclude_unset=True)
+def unpack_schema(
+    schema: BaseSchema,
+    exclude_unset: bool = True,
+    exclude: set[str] | None = None,
+) -> dict[str, Any]:
+    return schema.model_dump(exclude_unset=exclude_unset, exclude=exclude)
 
 
 def to_model(model: type[TO_MODEL], schema: BaseSchema) -> TO_MODEL:


### PR DESCRIPTION
This pull request includes several changes to the `mixemy` repository, focusing on improving the filtering logic and simplifying the codebase by removing the `PaginationSchemaType`. The most important changes include modifying the `_add_after_filter` and `_add_before_filter` methods, updating the `read_multi` and `count` methods, and enhancing the `unpack_schema` utility function.

Improvements to filtering logic:

* [`src/mixemy/repositories/_base/_audit.py`](diffhunk://#diff-365a649a9c2652ea08662d5da98781481e16912195e1033b4f7306424126df55R7-R25): Updated the `_add_after_filter` method to use `InputSchema` instead of `PaginationSchemaType` and added a call to the superclass method.
* [`src/mixemy/repositories/_base/_base.py`](diffhunk://#diff-4b5899ab62146d45c0e113b49e9e51b1debe555438781c6b753ce0ffdf18ba82L4-R9): Modified the `_add_after_filter` and `_add_before_filter` methods to use `InputSchema` and added a new `_add_filters` method to combine both filters. [[1]](diffhunk://#diff-4b5899ab62146d45c0e113b49e9e51b1debe555438781c6b753ce0ffdf18ba82L4-R9) [[2]](diffhunk://#diff-4b5899ab62146d45c0e113b49e9e51b1debe555438781c6b753ce0ffdf18ba82L22-R54)
* [`src/mixemy/repositories/asyncio/_base.py`](diffhunk://#diff-d541d244288c7d5f5328c8d72f3b629abf0b75df3a009cdbcedc8e17571c668bL12): Updated the `read_multi` and `count` methods to use the new `_add_filters` method. [[1]](diffhunk://#diff-d541d244288c7d5f5328c8d72f3b629abf0b75df3a009cdbcedc8e17571c668bL12) [[2]](diffhunk://#diff-d541d244288c7d5f5328c8d72f3b629abf0b75df3a009cdbcedc8e17571c668bL25-R28) [[3]](diffhunk://#diff-d541d244288c7d5f5328c8d72f3b629abf0b75df3a009cdbcedc8e17571c668bL59-R52)
* [`src/mixemy/repositories/sync/_base.py`](diffhunk://#diff-906d60646ac902e676d8ac6ab71f8b1bb75198df981a0eeb3c90f2884e3ed932L12): Updated the `read_multi` and `count` methods to use the new `_add_filters` method. [[1]](diffhunk://#diff-906d60646ac902e676d8ac6ab71f8b1bb75198df981a0eeb3c90f2884e3ed932L12) [[2]](diffhunk://#diff-906d60646ac902e676d8ac6ab71f8b1bb75198df981a0eeb3c90f2884e3ed932L23-R26) [[3]](diffhunk://#diff-906d60646ac902e676d8ac6ab71f8b1bb75198df981a0eeb3c90f2884e3ed932L57-R50)

Codebase simplification:

* [`src/mixemy/schemas/paginations/__init__.py`](diffhunk://#diff-4030f307e411d42f241bc0b1ec7fd08adf346254e84db5063049c813996bd3f9L5-R13): Added `PaginationFields` to the exports and included it in the `__all__` list.
* [`src/mixemy/utils/_convertors.py`](diffhunk://#diff-ecc58c23585872dbf1d6a4cf0eaee1d6905e87b15bacf3516a3ca1a498fb8195L10-R15): Enhanced the `unpack_schema` function to accept `exclude_unset` and `exclude` parameters for more flexible schema unpacking.