### PR TITLE
Table Naming

### DIFF
--- a/src/mixemy/models/_base.py
+++ b/src/mixemy/models/_base.py
@@ -8,7 +8,10 @@ class BaseModel(DeclarativeBase):
     @declared_attr  # pyright: ignore[reportArgumentType]
     @classmethod
     def __tablename__(cls) -> str:
-        return cls.__name__.lower()
+        return "".join(
+            (letter if letter.islower() else "_" + letter.lower())
+            for letter in (cls.__name__[0].lower() + cls.__name__[1:])
+        ).removesuffix("_model")
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} {self.__dict__}>"


### PR DESCRIPTION
This pull request includes a change to the `BaseModel` class in the file `src/mixemy/models/_base.py`. The change modifies the `__tablename__` method to generate table names with underscores before each uppercase letter and to remove the suffix `_model`.

* [`src/mixemy/models/_base.py`](diffhunk://#diff-d7757a5c6a8102e961cc1d38f415c78d75a1a7aa1df54e445ba94ce9c2941143L11-R14): Modified the `__tablename__` method to generate table names with underscores before each uppercase letter and to remove the suffix `_model`.