### PR TITLE
Correct Pagination Base Type

### DIFF
--- a/src/mixemy/schemas/paginations/_base.py
+++ b/src/mixemy/schemas/paginations/_base.py
@@ -1,8 +1,8 @@
 from pydantic import Field
 
-from mixemy.schemas._base import BaseSchema
+from mixemy.schemas._input import InputSchema
 
 
-class PaginationFilter(BaseSchema):
+class PaginationFilter(InputSchema):
     limit: int = Field(100, gt=0, le=500)
     offset: int = Field(0, ge=0)


### PR DESCRIPTION
This pull request includes a change to the `PaginationFilter` class to improve its schema inheritance.

Schema inheritance improvement:

* [`src/mixemy/schemas/paginations/_base.py`](diffhunk://#diff-9d8a393bef27ae4eb68ad48ea5ee3dfd074330354ed9251f42598bfef7fb05b9L3-R6): Changed the `PaginationFilter` class to inherit from `InputSchema` instead of `BaseSchema` to align with the updated schema structure.