### PR TITLE
Update permisssions and deps for workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,6 +49,6 @@ jobs:
           path: dist/
 
       - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
         with:
           packages-dir: dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,15 @@
 name: CI
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
This pull request includes updates to the continuous deployment and integration workflows in the GitHub Actions configuration files. The most important changes include updating the action used for publishing to PyPI and modifying the CI workflow to adjust permissions and trigger conditions.

Updates to the continuous deployment workflow:

* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L52-R52): Updated the `pypa/gh-action-pypi-publish` action to a specific commit hash for more stability and reproducibility.

Modifications to the continuous integration workflow:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL4-L11): Removed the push trigger for the `main` branch and added permissions for contents read and pull-requests write.