### PR TITLE
Defaults for auto values

### DIFF
--- a/src/mixemy/repositories/asyncio/_base.py
+++ b/src/mixemy/repositories/asyncio/_base.py
@@ -40,6 +40,7 @@ class BaseAsyncRepository(BaseRepository[BaseModelType], ABC):
         loader_options: tuple[_AbstractLoad] | None = None,
         execution_options: dict[str, Any] | None = None,
         auto_expunge: bool | None = None,
+        auto_commit: bool | None = False,
     ) -> BaseModelType | None:
         return await self._get(
             db_session=db_session,
@@ -47,6 +48,7 @@ class BaseAsyncRepository(BaseRepository[BaseModelType], ABC):
             loader_options=loader_options,
             execution_options=execution_options,
             auto_expunge=auto_expunge,
+            auto_commit=auto_commit,
         )
 
     async def read_multiple(
@@ -56,9 +58,8 @@ class BaseAsyncRepository(BaseRepository[BaseModelType], ABC):
         *,
         loader_options: tuple[_AbstractLoad] | None = None,
         execution_options: dict[str, Any] | None = None,
-        auto_commit: bool | None = None,
+        auto_commit: bool | None = False,
         auto_expunge: bool | None = None,
-        auto_refresh: bool | None = None,
     ) -> Sequence[BaseModelType]:
         statement = select(self.model)
         statement = self._add_filters(statement=statement, filters=filters)
@@ -70,7 +71,7 @@ class BaseAsyncRepository(BaseRepository[BaseModelType], ABC):
             execution_options=execution_options,
             auto_commit=auto_commit,
             auto_expunge=auto_expunge,
-            auto_refresh=auto_refresh,
+            auto_refresh=False,
         )
 
     async def update(
@@ -170,6 +171,7 @@ class BaseAsyncRepository(BaseRepository[BaseModelType], ABC):
         *,
         loader_options: tuple[_AbstractLoad] | None = None,
         execution_options: dict[str, Any] | None = None,
+        auto_commit: bool | None = False,
     ) -> int:
         statement = select(func.count()).select_from(self.model)
         statement = self._add_filters(statement=statement, filters=filters)
@@ -178,7 +180,7 @@ class BaseAsyncRepository(BaseRepository[BaseModelType], ABC):
             statement=statement,
             loader_options=loader_options,
             execution_options=execution_options,
-            auto_commit=False,
+            auto_commit=auto_commit,
             auto_expunge=False,
             auto_refresh=False,
         )
@@ -253,6 +255,7 @@ class BaseAsyncRepository(BaseRepository[BaseModelType], ABC):
         loader_options: tuple[_AbstractLoad] | None,
         execution_options: dict[str, Any] | None,
         auto_expunge: bool | None,
+        auto_commit: bool | None = False,
     ) -> BaseModelType | None:
         current_loader_options = (
             loader_options if loader_options is not None else self.loader_options
@@ -271,7 +274,7 @@ class BaseAsyncRepository(BaseRepository[BaseModelType], ABC):
         await self._maybe_commit_or_flush_or_refresh_or_expunge(
             db_session=db_session,
             db_object=db_object,
-            auto_commit=False,
+            auto_commit=auto_commit,
             auto_expunge=auto_expunge,
             auto_refresh=False,
         )

--- a/src/mixemy/repositories/sync/_base.py
+++ b/src/mixemy/repositories/sync/_base.py
@@ -40,6 +40,7 @@ class BaseSyncRepository(BaseRepository[BaseModelType], ABC):
         loader_options: tuple[_AbstractLoad] | None = None,
         execution_options: dict[str, Any] | None = None,
         auto_expunge: bool | None = None,
+        auto_commit: bool | None = False,
     ) -> BaseModelType | None:
         return self._get(
             db_session=db_session,
@@ -47,6 +48,7 @@ class BaseSyncRepository(BaseRepository[BaseModelType], ABC):
             loader_options=loader_options,
             execution_options=execution_options,
             auto_expunge=auto_expunge,
+            auto_commit=auto_commit,
         )
 
     def read_multiple(
@@ -56,9 +58,8 @@ class BaseSyncRepository(BaseRepository[BaseModelType], ABC):
         *,
         loader_options: tuple[_AbstractLoad] | None = None,
         execution_options: dict[str, Any] | None = None,
-        auto_commit: bool | None = None,
+        auto_commit: bool | None = False,
         auto_expunge: bool | None = None,
-        auto_refresh: bool | None = None,
     ) -> Sequence[BaseModelType]:
         statement = select(self.model)
         statement = self._add_filters(statement=statement, filters=filters)
@@ -70,7 +71,7 @@ class BaseSyncRepository(BaseRepository[BaseModelType], ABC):
             execution_options=execution_options,
             auto_commit=auto_commit,
             auto_expunge=auto_expunge,
-            auto_refresh=auto_refresh,
+            auto_refresh=False,
         )
 
     def update(
@@ -170,6 +171,7 @@ class BaseSyncRepository(BaseRepository[BaseModelType], ABC):
         *,
         loader_options: tuple[_AbstractLoad] | None = None,
         execution_options: dict[str, Any] | None = None,
+        auto_commit: bool | None = False,
     ) -> int:
         statement = select(func.count()).select_from(self.model)
         statement = self._add_filters(statement=statement, filters=filters)
@@ -178,7 +180,7 @@ class BaseSyncRepository(BaseRepository[BaseModelType], ABC):
             statement=statement,
             loader_options=loader_options,
             execution_options=execution_options,
-            auto_commit=False,
+            auto_commit=auto_commit,
             auto_expunge=False,
             auto_refresh=False,
         )
@@ -253,6 +255,7 @@ class BaseSyncRepository(BaseRepository[BaseModelType], ABC):
         loader_options: tuple[_AbstractLoad] | None,
         execution_options: dict[str, Any] | None,
         auto_expunge: bool | None,
+        auto_commit: bool | None = False,
     ) -> BaseModelType | None:
         current_loader_options = (
             loader_options if loader_options is not None else self.loader_options
@@ -271,7 +274,7 @@ class BaseSyncRepository(BaseRepository[BaseModelType], ABC):
         self._maybe_commit_or_flush_or_refresh_or_expunge(
             db_session=db_session,
             db_object=db_object,
-            auto_commit=False,
+            auto_commit=auto_commit,
             auto_expunge=auto_expunge,
             auto_refresh=False,
         )

--- a/src/mixemy/services/asyncio/_base.py
+++ b/src/mixemy/services/asyncio/_base.py
@@ -60,6 +60,7 @@ class BaseAsyncService(
         loader_options: tuple[_AbstractLoad] | None = None,
         execution_options: dict[str, Any] | None = None,
         auto_expunge: bool | None = None,
+        auto_commit: bool | None = None,
     ) -> OutputSchemaType | None:
         return (
             self._to_schema(model=model)
@@ -70,6 +71,7 @@ class BaseAsyncService(
                     loader_options=loader_options,
                     execution_options=execution_options,
                     auto_expunge=auto_expunge,
+                    auto_commit=auto_commit,
                 )
             )
             else None
@@ -82,7 +84,6 @@ class BaseAsyncService(
         loader_options: tuple[_AbstractLoad] | None = None,
         execution_options: dict[str, Any] | None = None,
         auto_expunge: bool | None = None,
-        auto_refresh: bool | None = None,
         auto_commit: bool | None = None,
     ) -> list[OutputSchemaType]:
         return [
@@ -93,7 +94,6 @@ class BaseAsyncService(
                 loader_options=loader_options,
                 execution_options=execution_options,
                 auto_expunge=auto_expunge,
-                auto_refresh=auto_refresh,
                 auto_commit=auto_commit,
             )
         ]

--- a/src/mixemy/services/sync/_base.py
+++ b/src/mixemy/services/sync/_base.py
@@ -60,6 +60,7 @@ class BaseSyncService(
         loader_options: tuple[_AbstractLoad] | None = None,
         execution_options: dict[str, Any] | None = None,
         auto_expunge: bool | None = None,
+        auto_commit: bool | None = None,
     ) -> OutputSchemaType | None:
         return (
             self._to_schema(model=model)
@@ -70,6 +71,7 @@ class BaseSyncService(
                     loader_options=loader_options,
                     execution_options=execution_options,
                     auto_expunge=auto_expunge,
+                    auto_commit=auto_commit,
                 )
             )
             else None
@@ -82,7 +84,6 @@ class BaseSyncService(
         loader_options: tuple[_AbstractLoad] | None = None,
         execution_options: dict[str, Any] | None = None,
         auto_expunge: bool | None = None,
-        auto_refresh: bool | None = None,
         auto_commit: bool | None = None,
     ) -> list[OutputSchemaType]:
         return [
@@ -93,7 +94,6 @@ class BaseSyncService(
                 loader_options=loader_options,
                 execution_options=execution_options,
                 auto_expunge=auto_expunge,
-                auto_refresh=auto_refresh,
                 auto_commit=auto_commit,
             )
         ]


### PR DESCRIPTION
This pull request includes changes to the `read`, `read_multiple`, and `count` methods in both asynchronous and synchronous repository and service classes. The changes mainly focus on modifying the default values of the `auto_commit` and `auto_refresh` parameters.

### Changes to Asynchronous Repository Methods:
* [`src/mixemy/repositories/asyncio/_base.py`](diffhunk://#diff-d541d244288c7d5f5328c8d72f3b629abf0b75df3a009cdbcedc8e17571c668bR43-R51): Updated the `read`, `read_multiple`, and `count` methods to set the default value of the `auto_commit` parameter to `False`. [[1]](diffhunk://#diff-d541d244288c7d5f5328c8d72f3b629abf0b75df3a009cdbcedc8e17571c668bR43-R51) [[2]](diffhunk://#diff-d541d244288c7d5f5328c8d72f3b629abf0b75df3a009cdbcedc8e17571c668bL59-L61) [[3]](diffhunk://#diff-d541d244288c7d5f5328c8d72f3b629abf0b75df3a009cdbcedc8e17571c668bR174)
* [`src/mixemy/repositories/asyncio/_base.py`](diffhunk://#diff-d541d244288c7d5f5328c8d72f3b629abf0b75df3a009cdbcedc8e17571c668bR258): Modified the `_get` method to include the `auto_commit` parameter with a default value of `False`.

### Changes to Synchronous Repository Methods:
* [`src/mixemy/repositories/sync/_base.py`](diffhunk://#diff-906d60646ac902e676d8ac6ab71f8b1bb75198df981a0eeb3c90f2884e3ed932R43-R51): Updated the `read`, `read_multiple`, and `count` methods to set the default value of the `auto_commit` parameter to `False`. [[1]](diffhunk://#diff-906d60646ac902e676d8ac6ab71f8b1bb75198df981a0eeb3c90f2884e3ed932R43-R51) [[2]](diffhunk://#diff-906d60646ac902e676d8ac6ab71f8b1bb75198df981a0eeb3c90f2884e3ed932L59-L61) [[3]](diffhunk://#diff-906d60646ac902e676d8ac6ab71f8b1bb75198df981a0eeb3c90f2884e3ed932R174)
* [`src/mixemy/repositories/sync/_base.py`](diffhunk://#diff-906d60646ac902e676d8ac6ab71f8b1bb75198df981a0eeb3c90f2884e3ed932R258): Modified the `_get` method to include the `auto_commit` parameter with a default value of `False`.

### Changes to Asynchronous Service Methods:
* [`src/mixemy/services/asyncio/_base.py`](diffhunk://#diff-2f6baa4b66d095d99c908ccdf7e1b5c9a0546de42860b7c7e7c12d59d0f85bbeR63): Added the `auto_commit` parameter to the `read` and `read_multiple` methods. [[1]](diffhunk://#diff-2f6baa4b66d095d99c908ccdf7e1b5c9a0546de42860b7c7e7c12d59d0f85bbeR63) [[2]](diffhunk://#diff-2f6baa4b66d095d99c908ccdf7e1b5c9a0546de42860b7c7e7c12d59d0f85bbeL85)

### Changes to Synchronous Service Methods:
* [`src/mixemy/services/sync/_base.py`](diffhunk://#diff-ab8a8607d672888694a9f3b212efa5d7fbcbd771486422b4d83892c86c11f533R63): Added the `auto_commit` parameter to the `read` and `read_multiple` methods. [[1]](diffhunk://#diff-ab8a8607d672888694a9f3b212efa5d7fbcbd771486422b4d83892c86c11f533R63) [[2]](diffhunk://#diff-ab8a8607d672888694a9f3b212efa5d7fbcbd771486422b4d83892c86c11f533L85)

These changes ensure consistency in the handling of the `auto_commit` parameter across both asynchronous and synchronous methods in the repository and service layers.