### PR TITLE
Add with_for_update

### DIFF
--- a/src/mixemy/repositories/_base/_base.py
+++ b/src/mixemy/repositories/_base/_base.py
@@ -87,7 +87,7 @@ class BaseRepository(Generic[BaseModelType], ABC):
         *,
         loader_options: tuple[_AbstractLoad] | None,
         execution_options: dict[str, Any] | None,
-        with_for_update: bool = False,
+        with_for_update: bool,
     ) -> Select[SelectT]:
         current_loader_options = (
             loader_options if loader_options is not None else self.loader_options

--- a/src/mixemy/repositories/asyncio/_base.py
+++ b/src/mixemy/repositories/asyncio/_base.py
@@ -41,6 +41,7 @@ class BaseAsyncRepository(BaseRepository[BaseModelType], ABC):
         execution_options: dict[str, Any] | None = None,
         auto_expunge: bool | None = None,
         auto_commit: bool | None = False,
+        with_for_update: bool = False,
     ) -> BaseModelType | None:
         return await self._get(
             db_session=db_session,
@@ -49,6 +50,7 @@ class BaseAsyncRepository(BaseRepository[BaseModelType], ABC):
             execution_options=execution_options,
             auto_expunge=auto_expunge,
             auto_commit=auto_commit,
+            with_for_update=with_for_update,
         )
 
     async def read_multiple(
@@ -60,6 +62,7 @@ class BaseAsyncRepository(BaseRepository[BaseModelType], ABC):
         execution_options: dict[str, Any] | None = None,
         auto_commit: bool | None = False,
         auto_expunge: bool | None = None,
+        with_for_update: bool = False,
     ) -> Sequence[BaseModelType]:
         statement = select(self.model)
         statement = self._add_filters(statement=statement, filters=filters)
@@ -72,6 +75,7 @@ class BaseAsyncRepository(BaseRepository[BaseModelType], ABC):
             auto_commit=auto_commit,
             auto_expunge=auto_expunge,
             auto_refresh=False,
+            with_for_update=with_for_update,
         )
 
     async def update(
@@ -85,13 +89,16 @@ class BaseAsyncRepository(BaseRepository[BaseModelType], ABC):
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
         auto_refresh: bool | None = None,
+        with_for_update: bool = True,
     ) -> BaseModelType | None:
         db_object = await self._get(
             db_session=db_session,
             id=id,
             loader_options=loader_options,
             execution_options=execution_options,
-            auto_expunge=auto_expunge,
+            auto_expunge=False,
+            with_for_update=with_for_update,
+            auto_commit=False,
         )
         if db_object is not None:
             return await self.update_db_object(
@@ -102,6 +109,14 @@ class BaseAsyncRepository(BaseRepository[BaseModelType], ABC):
                 auto_expunge=auto_expunge,
                 auto_refresh=auto_refresh,
             )
+
+        await self._maybe_commit_or_flush_or_refresh_or_expunge(
+            db_session=db_session,
+            db_object=db_object,
+            auto_commit=auto_commit,
+            auto_expunge=auto_expunge,
+            auto_refresh=auto_refresh,
+        )
 
         return db_object
 
@@ -133,13 +148,16 @@ class BaseAsyncRepository(BaseRepository[BaseModelType], ABC):
         execution_options: dict[str, Any] | None = None,
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
+        with_for_update: bool = False,
     ) -> None:
         db_object = await self._get(
             db_session=db_session,
             id=id,
             loader_options=loader_options,
             execution_options=execution_options,
-            auto_expunge=auto_expunge,
+            auto_expunge=False,
+            auto_commit=False,
+            with_for_update=with_for_update,
         )
         if db_object is not None:
             await self.delete_db_object(
@@ -147,6 +165,14 @@ class BaseAsyncRepository(BaseRepository[BaseModelType], ABC):
                 db_object=db_object,
                 auto_commit=auto_commit,
                 auto_expunge=auto_expunge,
+            )
+        else:
+            await self._maybe_commit_or_flush_or_refresh_or_expunge(
+                db_session=db_session,
+                db_object=db_object,
+                auto_commit=auto_commit,
+                auto_expunge=auto_expunge,
+                auto_refresh=False,
             )
 
     async def delete_db_object(
@@ -183,6 +209,7 @@ class BaseAsyncRepository(BaseRepository[BaseModelType], ABC):
             auto_commit=auto_commit,
             auto_expunge=False,
             auto_refresh=False,
+            with_for_update=False,
         )
 
     async def _maybe_commit_or_flush_or_refresh_or_expunge(
@@ -255,6 +282,7 @@ class BaseAsyncRepository(BaseRepository[BaseModelType], ABC):
         loader_options: tuple[_AbstractLoad] | None,
         execution_options: dict[str, Any] | None,
         auto_expunge: bool | None,
+        with_for_update: bool = False,
         auto_commit: bool | None = False,
     ) -> BaseModelType | None:
         current_loader_options = (
@@ -270,6 +298,7 @@ class BaseAsyncRepository(BaseRepository[BaseModelType], ABC):
             id,
             options=current_loader_options,
             execution_options=current_execution_options or EMPTY_DICT,
+            with_for_update=with_for_update,
         )
         await self._maybe_commit_or_flush_or_refresh_or_expunge(
             db_session=db_session,
@@ -291,11 +320,13 @@ class BaseAsyncRepository(BaseRepository[BaseModelType], ABC):
         auto_commit: bool | None,
         auto_expunge: bool | None,
         auto_refresh: bool | None,
+        with_for_update: bool = False,
     ) -> Sequence[Any]:
         statement = self._prepare_statement(
             statement=statement,
             loader_options=loader_options,
             execution_options=execution_options,
+            with_for_update=with_for_update,
         )
         res = await db_session.execute(statement)
         db_objects: Sequence[Any] = res.scalars().all()
@@ -318,11 +349,13 @@ class BaseAsyncRepository(BaseRepository[BaseModelType], ABC):
         auto_commit: bool | None,
         auto_expunge: bool | None,
         auto_refresh: bool | None,
+        with_for_update: bool = False,
     ) -> Any:
         statement = self._prepare_statement(
             statement=statement,
             loader_options=loader_options,
             execution_options=execution_options,
+            with_for_update=with_for_update,
         )
         res = await db_session.execute(statement)
         db_object = res.scalar_one()


### PR DESCRIPTION
This pull request introduces a new `with_for_update` parameter to various asynchronous and synchronous repository methods in the `mixemy` project. The parameter is intended to handle row-level locking in SQL queries. The most important changes include updates to the `_prepare_statement`, `read`, `read_multiple`, `update`, `delete`, `count`, `_get`, `_execute_returning_all`, and `_execute_returning_one` methods.

### Asynchronous repository updates:
* Added `with_for_update` parameter to `read`, `read_multiple`, `update`, `delete`, `count`, `_get`, `_execute_returning_all`, and `_execute_returning_one` methods in `src/mixemy/repositories/asyncio/_base.py`. [[1]](diffhunk://#diff-d541d244288c7d5f5328c8d72f3b629abf0b75df3a009cdbcedc8e17571c668bR44) [[2]](diffhunk://#diff-d541d244288c7d5f5328c8d72f3b629abf0b75df3a009cdbcedc8e17571c668bR53) [[3]](diffhunk://#diff-d541d244288c7d5f5328c8d72f3b629abf0b75df3a009cdbcedc8e17571c668bR65) [[4]](diffhunk://#diff-d541d244288c7d5f5328c8d72f3b629abf0b75df3a009cdbcedc8e17571c668bR78) [[5]](diffhunk://#diff-d541d244288c7d5f5328c8d72f3b629abf0b75df3a009cdbcedc8e17571c668bR92-R101) [[6]](diffhunk://#diff-d541d244288c7d5f5328c8d72f3b629abf0b75df3a009cdbcedc8e17571c668bR113-R120) [[7]](diffhunk://#diff-d541d244288c7d5f5328c8d72f3b629abf0b75df3a009cdbcedc8e17571c668bR151-R160) [[8]](diffhunk://#diff-d541d244288c7d5f5328c8d72f3b629abf0b75df3a009cdbcedc8e17571c668bR169-R176) [[9]](diffhunk://#diff-d541d244288c7d5f5328c8d72f3b629abf0b75df3a009cdbcedc8e17571c668bR212) [[10]](diffhunk://#diff-d541d244288c7d5f5328c8d72f3b629abf0b75df3a009cdbcedc8e17571c668bR285) [[11]](diffhunk://#diff-d541d244288c7d5f5328c8d72f3b629abf0b75df3a009cdbcedc8e17571c668bR301) [[12]](diffhunk://#diff-d541d244288c7d5f5328c8d72f3b629abf0b75df3a009cdbcedc8e17571c668bR323-R329) [[13]](diffhunk://#diff-d541d244288c7d5f5328c8d72f3b629abf0b75df3a009cdbcedc8e17571c668bR352-R358)

### Synchronous repository updates:
* Added `with_for_update` parameter to `read`, `read_multiple`, `update`, `delete`, `count`, `_get`, `_execute_returning_all`, and `_execute_returning_one` methods in `src/mixemy/repositories/sync/_base.py`. [[1]](diffhunk://#diff-906d60646ac902e676d8ac6ab71f8b1bb75198df981a0eeb3c90f2884e3ed932R44) [[2]](diffhunk://#diff-906d60646ac902e676d8ac6ab71f8b1bb75198df981a0eeb3c90f2884e3ed932R53) [[3]](diffhunk://#diff-906d60646ac902e676d8ac6ab71f8b1bb75198df981a0eeb3c90f2884e3ed932R65) [[4]](diffhunk://#diff-906d60646ac902e676d8ac6ab71f8b1bb75198df981a0eeb3c90f2884e3ed932R78) [[5]](diffhunk://#diff-906d60646ac902e676d8ac6ab71f8b1bb75198df981a0eeb3c90f2884e3ed932R92-R101) [[6]](diffhunk://#diff-906d60646ac902e676d8ac6ab71f8b1bb75198df981a0eeb3c90f2884e3ed932R113-R120) [[7]](diffhunk://#diff-906d60646ac902e676d8ac6ab71f8b1bb75198df981a0eeb3c90f2884e3ed932R151-R160) [[8]](diffhunk://#diff-906d60646ac902e676d8ac6ab71f8b1bb75198df981a0eeb3c90f2884e3ed932R169-R176) [[9]](diffhunk://#diff-906d60646ac902e676d8ac6ab71f8b1bb75198df981a0eeb3c90f2884e3ed932R212) [[10]](diffhunk://#diff-906d60646ac902e676d8ac6ab71f8b1bb75198df981a0eeb3c90f2884e3ed932R285) [[11]](diffhunk://#diff-906d60646ac902e676d8ac6ab71f8b1bb75198df981a0eeb3c90f2884e3ed932R301) [[12]](diffhunk://#diff-906d60646ac902e676d8ac6ab71f8b1bb75198df981a0eeb3c90f2884e3ed932R323-R329) [[13]](diffhunk://#diff-906d60646ac902e676d8ac6ab71f8b1bb75198df981a0eeb3c90f2884e3ed932R352-R358)

### Base repository update:
* Removed default value for `with_for_update` parameter in `_prepare_statement` method in `src/mixemy/repositories/_base/_base.py`.