### PR TITLE
Enable serialization via alias

### DIFF
--- a/src/mixemy/utils/_convertors.py
+++ b/src/mixemy/utils/_convertors.py
@@ -7,10 +7,14 @@ from mixemy.types import BaseModelT, BaseSchemaT
 
 def unpack_schema(
     schema: BaseSchema,
+    *,
     exclude_unset: bool = True,
     exclude: set[str] | None = None,
+    by_alias: bool = True,
 ) -> dict[str, Any]:
-    return schema.model_dump(exclude_unset=exclude_unset, exclude=exclude)
+    return schema.model_dump(
+        exclude_unset=exclude_unset, exclude=exclude, by_alias=by_alias
+    )
 
 
 def to_model(model: type[BaseModelT], schema: BaseSchema) -> BaseModelT:


### PR DESCRIPTION
This pull request includes a small change to the `src/mixemy/utils/_convertors.py` file. The change modifies the `unpack_schema` function to add a `by_alias` parameter and includes it in the call to `schema.model_dump`. 

* [`src/mixemy/utils/_convertors.py`](diffhunk://#diff-ecc58c23585872dbf1d6a4cf0eaee1d6905e87b15bacf3516a3ca1a498fb8195R10-R17): Added `by_alias` parameter to `unpack_schema` function and included it in the call to `schema.model_dump`.