### PR TITLE
Enable one-to-many bulk insert

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ fixable = ["ALL"]
 unfixable = ["T20", "ERA001"]
 
 [tool.ruff.per-file-ignores]
-"tests/**/*.py" = ["S101", "ARG001", "PLR2004"]
+"tests/**/*.py" = ["S101", "ARG001", "PLR2004", "N806"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/mixemy/_exceptions.py
+++ b/src/mixemy/_exceptions.py
@@ -1,13 +1,33 @@
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from mixemy.models import BaseModel
     from mixemy.repositories import BaseAsyncRepository, BaseSyncRepository
+    from mixemy.schemas import BaseSchema
     from mixemy.services import BaseAsyncService, BaseSyncService
 
 
 class MixemyError(Exception):
     def __init__(self, message: str) -> None:
         self.message = message
+        super().__init__(message)
+
+
+class MixemyConversionError(MixemyError):
+    def __init__(
+        self,
+        model: "BaseModel | type[BaseModel]",
+        schema: "BaseSchema | type[BaseSchema]",
+        is_model_to_schema: bool,
+        message: str | None = None,
+    ) -> None:
+        if message is None:
+            if is_model_to_schema:
+                message = f"Error converting {model} to {schema}.\nThis is likely due to a mismatch between the model and schema"
+            else:
+                message = f"Error converting {schema} to {model}.\nThis is likely due to a mismatch between the schema and model"
+        self.model = model
+        self.schema = schema
         super().__init__(message)
 
 

--- a/src/mixemy/services/_asyncio.py
+++ b/src/mixemy/services/_asyncio.py
@@ -68,17 +68,45 @@ class BaseAsyncService(
     repository_type: type[RepositoryAsyncT]
     output_schema_type: type[OutputSchemaT]
 
-    def __init__(self, db_session: AsyncSession) -> None:
+    default_model_recursive_model_conversion: bool = False
+    default_schema_exclude_unset: bool = True
+    default_schema_exclude: set[str] | None = None
+    default_schema_by_alias: bool = True
+
+    def __init__(
+        self,
+        db_session: AsyncSession,
+        *,
+        recursive_model_conversion: bool | None = None,
+        exclude_unset: bool | None = None,
+        exclude: set[str] | None = None,
+        by_alias: bool | None = None,
+    ) -> None:
         self._verify_init()
         self.output_schema = self.output_schema_type
         self.repository = self.repository_type()
         self.model = self.repository.model
         self.db_session = db_session
+        self.recursive_model_conversion = (
+            recursive_model_conversion
+            if recursive_model_conversion is not None
+            else self.default_model_recursive_model_conversion
+        )
+        self.exclude_unset = (
+            exclude_unset
+            if exclude_unset is not None
+            else self.default_schema_exclude_unset
+        )
+        self.exclude = exclude if exclude is not None else self.default_schema_exclude
+        self.by_alias = (
+            by_alias if by_alias is not None else self.default_schema_by_alias
+        )
 
     async def create(
         self,
         object_in: CreateSchemaT,
         *,
+        recursive_model_conversion: bool | None = None,
         auto_expunge: bool | None = None,
         auto_refresh: bool | None = None,
         auto_commit: bool | None = None,
@@ -86,7 +114,10 @@ class BaseAsyncService(
         return self._to_schema(
             model=await self.repository.create(
                 db_session=self.db_session,
-                db_object=self._to_model(schema=object_in),
+                db_object=self._to_model(
+                    schema=object_in,
+                    recursive_model_conversion=recursive_model_conversion,
+                ),
                 auto_expunge=auto_expunge,
                 auto_refresh=auto_refresh,
                 auto_commit=auto_commit,
@@ -184,8 +215,33 @@ class BaseAsyncService(
             execution_options=execution_options,
         )
 
-    def _to_model(self, schema: CreateSchemaT | UpdateSchemaT) -> BaseModelT:
-        return to_model(schema=schema, model=self.model)
+    def _to_model(
+        self,
+        schema: CreateSchemaT | UpdateSchemaT,
+        *,
+        recursive_model_conversion: bool | None = None,
+        exclude_unset: bool | None = None,
+        exclude: set[str] | None = None,
+        by_alias: bool | None = None,
+    ) -> BaseModelT:
+        current_recursive_model_conversion = (
+            recursive_model_conversion
+            if recursive_model_conversion is not None
+            else self.recursive_model_conversion
+        )
+        current_exclude_unset = (
+            exclude_unset if exclude_unset is not None else self.exclude_unset
+        )
+        current_exclude = exclude if exclude is not None else self.exclude
+        current_by_alias = by_alias if by_alias is not None else self.by_alias
+        return to_model(
+            schema=schema,
+            model=self.model,
+            recursive_conversion=current_recursive_model_conversion,
+            exclude_unset=current_exclude_unset,
+            exclude=current_exclude,
+            by_alias=current_by_alias,
+        )
 
     def _to_schema(self, model: BaseModelT) -> OutputSchemaT:
         return to_schema(model=model, schema=self.output_schema)

--- a/src/mixemy/utils/_convertors.py
+++ b/src/mixemy/utils/_convertors.py
@@ -1,5 +1,9 @@
 from typing import Any
 
+from sqlalchemy.exc import ArgumentError
+from sqlalchemy.inspection import inspect
+
+from mixemy._exceptions import MixemyConversionError
 from mixemy.models import BaseModel
 from mixemy.schemas import BaseSchema
 from mixemy.types import BaseModelT, BaseSchemaT
@@ -17,9 +21,56 @@ def unpack_schema(
     )
 
 
-def to_model(model: type[BaseModelT], schema: BaseSchema) -> BaseModelT:
-    return model(**unpack_schema(schema=schema))
+def to_model(
+    model: type[BaseModelT],
+    schema: BaseSchema,
+    *,
+    recursive_conversion: bool = False,
+    exclude_unset: bool = True,
+    exclude: set[str] | None = None,
+    by_alias: bool = True,
+) -> BaseModelT:
+    sub_models: dict[str, list[BaseModel]] = {}
+    if recursive_conversion:
+        if exclude is None:
+            exclude = set()
+        relationships = inspect(model).relationships
+        for relationship in relationships:
+            if hasattr(schema, relationship.key):
+                sub_models[relationship.key] = []
+                for item in getattr(schema, relationship.key):
+                    sub_models[relationship.key].append(
+                        to_model(
+                            model=relationship.mapper.class_,
+                            schema=item,
+                            recursive_conversion=recursive_conversion,
+                            exclude_unset=exclude_unset,
+                            exclude=exclude,
+                            by_alias=by_alias,
+                        )
+                    )
+
+                exclude.add(relationship.key)
+
+    unpacked_schema = unpack_schema(
+        schema=schema,
+        exclude_unset=exclude_unset,
+        exclude=exclude,
+        by_alias=by_alias,
+    )
+
+    try:
+        return model(**unpacked_schema, **sub_models)
+    except ArgumentError as ex:
+        raise MixemyConversionError(
+            model=model, schema=schema, is_model_to_schema=False
+        ) from ex
 
 
 def to_schema(model: BaseModel, schema: type[BaseSchemaT]) -> BaseSchemaT:
-    return schema.model_validate(model)
+    try:
+        return schema.model_validate(model)
+    except ValueError as ex:
+        raise MixemyConversionError(
+            model=model, schema=schema, is_model_to_schema=True
+        ) from ex

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,11 @@
 from asyncio import current_task
 from collections.abc import AsyncGenerator, Generator
+from uuid import UUID
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import Engine, String, create_engine, make_url
+from sqlalchemy import UUID as SQLAUUID
+from sqlalchemy import Engine, ForeignKey, String, create_engine, make_url
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -11,8 +13,66 @@ from sqlalchemy.ext.asyncio import (
     async_sessionmaker,
     create_async_engine,
 )
-from sqlalchemy.orm import Mapped, Session, mapped_column, scoped_session, sessionmaker
+from sqlalchemy.orm import (
+    Mapped,
+    Session,
+    mapped_column,
+    relationship,
+    scoped_session,
+    sessionmaker,
+)
 from testcontainers.postgres import PostgresContainer
+
+from mixemy import models
+
+
+class AsyncItemModel(models.IdAuditModel):
+    __table_args__ = {"extend_existing": True}  # noqa: RUF012
+    value: Mapped[str] = mapped_column(String)
+
+
+class ItemModel(models.IdAuditModel):
+    __table_args__ = {"extend_existing": True}  # noqa: RUF012
+    value: Mapped[str] = mapped_column(String)
+    nullable_value: Mapped[str | None] = mapped_column(String, nullable=True)
+
+
+class RecursiveItemModel(models.IdAuditModel):
+    __table_args__ = {"extend_existing": True}  # noqa: RUF012
+
+    sub_items: Mapped[list["SubItemModel"]] = relationship(
+        "SubItemModel", back_populates="item"
+    )
+
+
+class SubItemModel(models.IdAuditModel):
+    __table_args__ = {"extend_existing": True}  # noqa: RUF012
+    value: Mapped[str] = mapped_column(String)
+    item_id: Mapped[UUID] = mapped_column(SQLAUUID, ForeignKey("recursive_item.id"))
+
+    item: Mapped["RecursiveItemModel"] = relationship(
+        "RecursiveItemModel", back_populates="sub_items"
+    )
+
+
+@pytest.fixture(scope="module")
+def item_model() -> type[ItemModel]:
+    return ItemModel
+
+
+@pytest.fixture(scope="module")
+def async_item_model() -> type[AsyncItemModel]:
+    return AsyncItemModel
+
+
+@pytest.fixture(scope="module")
+def recursive_item_model() -> type[RecursiveItemModel]:
+    return RecursiveItemModel
+
+
+@pytest.fixture(scope="module")
+def sub_item_model() -> type[SubItemModel]:
+    return SubItemModel
 
 
 @pytest.fixture(scope="module")
@@ -71,17 +131,10 @@ async def async_session(
 
 
 @pytest.fixture(scope="module")
-def init_db(engine: Engine) -> None:
-    from mixemy import models
-
-    class AsyncItemModel(models.IdAuditModel):
-        __table_args__ = {"extend_existing": True}  # noqa: RUF012
-        value: Mapped[str] = mapped_column(String)
-
-    class ItemModel(models.IdAuditModel):
-        __table_args__ = {"extend_existing": True}  # noqa: RUF012
-        value: Mapped[str] = mapped_column(String)
-        nullable_value: Mapped[str | None] = mapped_column(String, nullable=True)
-
+def init_db(
+    engine: Engine,
+) -> None:
     ItemModel.__table__.create(bind=engine)  # type: ignore - Only for testing
     AsyncItemModel.__table__.create(bind=engine)  # type: ignore - Only for testing
+    RecursiveItemModel.__table__.create(bind=engine)  # type: ignore - Only for testing
+    SubItemModel.__table__.create(bind=engine)  # type: ignore - Only for testing

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,18 +1,21 @@
+from typing import TYPE_CHECKING
+
 import pytest
-from sqlalchemy import String
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import Mapped, mapped_column
+
+if TYPE_CHECKING:
+    from mixemy.models import IdAuditModel
 
 
 @pytest.mark.database
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_main(async_session: AsyncSession, init_db: None) -> None:
-    from mixemy import models, repositories, schemas, services
+async def test_main(
+    async_session: AsyncSession, async_item_model: "type[IdAuditModel]", init_db: None
+) -> None:
+    from mixemy import repositories, schemas, services
 
-    class AsyncItemModel(models.IdAuditModel):
-        __table_args__ = {"extend_existing": True}  # noqa: RUF012
-        value: Mapped[str] = mapped_column(String)
+    AsyncItemModel = async_item_model
 
     class ItemInput(schemas.InputSchema):
         value: str


### PR DESCRIPTION
This pull request includes several changes to improve model conversion, error handling, and testing in the `mixemy` project. The changes introduce new classes, update existing methods, and add new tests to ensure the functionality of recursive model conversions and error handling.

### Model Conversion Enhancements:
* [`src/mixemy/services/_asyncio.py`](diffhunk://#diff-0b907da48e3f32e5bb5c71df6b1ead7b7d00f8810866b07fb7afe4c1573ae69cL71-R120): Added parameters to the `BaseAsyncService` constructor and `_to_model` method to support recursive model conversion and schema exclusion options. [[1]](diffhunk://#diff-0b907da48e3f32e5bb5c71df6b1ead7b7d00f8810866b07fb7afe4c1573ae69cL71-R120) [[2]](diffhunk://#diff-0b907da48e3f32e5bb5c71df6b1ead7b7d00f8810866b07fb7afe4c1573ae69cL187-R244)
* [`src/mixemy/services/_sync.py`](diffhunk://#diff-b8599b6c8551559fb994145277f14ee4b24868d9997a2fe8a688d8ba34672c35L71-R103): Similar updates to the `BaseSyncService` constructor and `_to_model` method to support recursive model conversion and schema exclusion options. [[1]](diffhunk://#diff-b8599b6c8551559fb994145277f14ee4b24868d9997a2fe8a688d8ba34672c35L71-R103) [[2]](diffhunk://#diff-b8599b6c8551559fb994145277f14ee4b24868d9997a2fe8a688d8ba34672c35L187-R240)
* [`src/mixemy/utils/_convertors.py`](diffhunk://#diff-ecc58c23585872dbf1d6a4cf0eaee1d6905e87b15bacf3516a3ca1a498fb8195L20-R76): Enhanced the `to_model` function to support recursive model conversion and added error handling with the new `MixemyConversionError` class.

### Error Handling:
* [`src/mixemy/_exceptions.py`](diffhunk://#diff-727763c915cb4412395662d25254bf07979bc301cf489d132ccfcc7a36b62bf4R16-R33): Introduced a new `MixemyConversionError` class to handle errors during model-to-schema and schema-to-model conversions.

### Testing Improvements:
* [`tests/conftest.py`](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R3-R76): Added new model classes and fixtures for testing recursive model relationships. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R3-R76) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L74-R140)
* [`tests/test_sync.py`](diffhunk://#diff-7cdc82c5ea3109d2377741f06aecdcce8d49257482335f49ee25be99853621b3R95-R152): Added a new test case `test_recursive_model` to verify the recursive model conversion functionality.

### Miscellaneous:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L61-R61): Updated per-file ignores to include `N806` for test files.