### PR TITLE
Support one-to-one for full mappings

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,9 @@ class RecursiveItemModel(models.IdAuditModel):
     sub_items: Mapped[list["SubItemModel"]] = relationship(
         "SubItemModel", back_populates="item"
     )
+    singular_sub_item: Mapped["SingularSubItemModel"] = relationship(
+        "SingularSubItemModel", back_populates="item"
+    )
 
 
 class SubItemModel(models.IdAuditModel):
@@ -52,6 +55,16 @@ class SubItemModel(models.IdAuditModel):
 
     item: Mapped["RecursiveItemModel"] = relationship(
         "RecursiveItemModel", back_populates="sub_items"
+    )
+
+
+class SingularSubItemModel(models.IdAuditModel):
+    __table_args__ = {"extend_existing": True}  # noqa: RUF012
+    value: Mapped[str] = mapped_column(String)
+    item_id: Mapped[UUID] = mapped_column(SQLAUUID, ForeignKey("recursive_item.id"))
+
+    item: Mapped["RecursiveItemModel"] = relationship(
+        "RecursiveItemModel", back_populates="singular_sub_item"
     )
 
 
@@ -73,6 +86,11 @@ def recursive_item_model() -> type[RecursiveItemModel]:
 @pytest.fixture(scope="module")
 def sub_item_model() -> type[SubItemModel]:
     return SubItemModel
+
+
+@pytest.fixture(scope="module")
+def singular_sub_item_model() -> type[SingularSubItemModel]:
+    return SingularSubItemModel
 
 
 @pytest.fixture(scope="module")
@@ -138,3 +156,4 @@ def init_db(
     AsyncItemModel.__table__.create(bind=engine)  # type: ignore - Only for testing
     RecursiveItemModel.__table__.create(bind=engine)  # type: ignore - Only for testing
     SubItemModel.__table__.create(bind=engine)  # type: ignore - Only for testing
+    SingularSubItemModel.__table__.create(bind=engine)  # type: ignore - Only for testing

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -95,10 +95,7 @@ def test_main(
 
 
 def test_recursive_model(
-    session: Session,
-    init_db: None,
-    recursive_item_model: "type[IdAuditModel]",
-    sub_item_model: "type[IdAuditModel]",
+    session: Session, init_db: None, recursive_item_model: "type[IdAuditModel]"
 ) -> None:
     from mixemy import repositories, schemas, services
 
@@ -107,14 +104,22 @@ def test_recursive_model(
     class SubItemInput(schemas.InputSchema):
         value: str
 
+    class SingularSubItemInput(schemas.InputSchema):
+        value: str
+
     class SubItemOutput(schemas.IdAuditOutputSchema):
+        value: str
+
+    class SingularSubItemOutput(schemas.IdAuditOutputSchema):
         value: str
 
     class ItemInput(schemas.InputSchema):
         sub_items: list[SubItemInput]
+        singular_sub_item: SingularSubItemInput
 
     class ItemOutput(schemas.IdAuditOutputSchema):
         sub_items: list[SubItemOutput]
+        singular_sub_item: SingularSubItemOutput
 
     class ItemRepository(repositories.BaseSyncRepository[RecursiveItemModel]):
         model_type = RecursiveItemModel
@@ -139,7 +144,8 @@ def test_recursive_model(
         sub_items=[
             SubItemInput(value="sub_item_one"),
             SubItemInput(value="sub_item_two"),
-        ]
+        ],
+        singular_sub_item=SingularSubItemInput(value="singular_sub_item"),
     )
 
     item_id = item_service.create(object_in=test_item).id
@@ -150,3 +156,4 @@ def test_recursive_model(
     assert len(item.sub_items) == 2
     assert item.sub_items[0].value == "sub_item_one"
     assert item.sub_items[1].value == "sub_item_two"
+    assert item.singular_sub_item.value == "singular_sub_item"


### PR DESCRIPTION
This pull request introduces several changes to the `to_model` function in `src/mixemy/utils/_convertors.py` and updates the test suite to support a new model relationship. The most important changes include modifying the `to_model` function to handle singular relationships, adding the `SingularSubItemModel` class, and updating the test fixtures and test cases to accommodate this new model.

Changes to handle singular relationships in `to_model` function:

* [`src/mixemy/utils/_convertors.py`](diffhunk://#diff-ecc58c23585872dbf1d6a4cf0eaee1d6905e87b15bacf3516a3ca1a498fb8195L33-R41): Modified the `to_model` function to handle both list and singular relationships by updating the `sub_models` dictionary and adding logic to check if the relationship is a list. [[1]](diffhunk://#diff-ecc58c23585872dbf1d6a4cf0eaee1d6905e87b15bacf3516a3ca1a498fb8195L33-R41) [[2]](diffhunk://#diff-ecc58c23585872dbf1d6a4cf0eaee1d6905e87b15bacf3516a3ca1a498fb8195R50-R60)

Additions to test models and fixtures:

* [`tests/conftest.py`](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R46-R48): Added the `SingularSubItemModel` class and updated the `RecursiveItemModel` to include a singular relationship. Added a new fixture `singular_sub_item_model` and updated the `init_db` function to create the new table. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R46-R48) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R61-R70) [[3]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R91-R95) [[4]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R159)

Updates to test cases:

* [`tests/test_sync.py`](diffhunk://#diff-7cdc82c5ea3109d2377741f06aecdcce8d49257482335f49ee25be99853621b3L98-R98): Updated the `test_recursive_model` test case to include the new singular sub-item relationship in the input and output schemas, and added assertions to check the singular sub-item value. [[1]](diffhunk://#diff-7cdc82c5ea3109d2377741f06aecdcce8d49257482335f49ee25be99853621b3L98-R98) [[2]](diffhunk://#diff-7cdc82c5ea3109d2377741f06aecdcce8d49257482335f49ee25be99853621b3R107-R122) [[3]](diffhunk://#diff-7cdc82c5ea3109d2377741f06aecdcce8d49257482335f49ee25be99853621b3L142-R148) [[4]](diffhunk://#diff-7cdc82c5ea3109d2377741f06aecdcce8d49257482335f49ee25be99853621b3R159)