### PR TITLE
fix: Exception inheritance

### DIFF
--- a/src/mixemy/exceptions/__init__.py
+++ b/src/mixemy/exceptions/__init__.py
@@ -39,7 +39,7 @@ class MixemyError(Exception):
             message (str): The error message to be associated with this exception.
         """
         self.message = message
-        super().__init__(message)
+        Exception.__init__(self, message)
 
 
 class MixemyConversionError(MixemyError, ValidationError):
@@ -113,7 +113,7 @@ class MixemyRepositoryError(MixemyError):
         if message is None:
             message = f"Error with repository {repository}."
         self.repository = repository
-        super().__init__(message)
+        MixemyError.__init__(self, message)
 
 
 class MixemyServiceError(MixemyError):
@@ -146,7 +146,7 @@ class MixemyServiceError(MixemyError):
         if message is None:
             message = f"Error with service {service}."
         self.service = service
-        super().__init__(message)
+        MixemyError.__init__(self, message)
 
 
 class MixemySetupError(MixemyError):
@@ -182,7 +182,7 @@ class MixemySetupError(MixemyError):
         if message is None:
             message = f"{component.__class__.__name__.capitalize()} {component} has undefined field '{undefined_field}'.\nThis probably needs to be defined as a class attribute."
         self.undefined_field = undefined_field
-        super().__init__(message=message)
+        MixemyError.__init__(self, message)
 
 
 class MixemyRepositorySetupError(MixemySetupError, MixemyRepositoryError):

--- a/src/mixemy/exceptions/__init__.py
+++ b/src/mixemy/exceptions/__init__.py
@@ -13,8 +13,6 @@ Classes:
 
 from typing import TYPE_CHECKING, Any
 
-from pydantic import ValidationError
-
 if TYPE_CHECKING:
     from mixemy.models import BaseModel
     from mixemy.repositories import BaseAsyncRepository, BaseSyncRepository
@@ -42,7 +40,7 @@ class MixemyError(Exception):
         Exception.__init__(self, message)
 
 
-class MixemyConversionError(MixemyError, ValidationError):
+class MixemyConversionError(MixemyError):
     """Exception raised for errors in the conversion between a model and a schema.
 
     Attributes:
@@ -82,7 +80,6 @@ class MixemyConversionError(MixemyError, ValidationError):
         self.model = model
         self.schema = schema
         MixemyError.__init__(self, message)
-        ValidationError.__init__(self, message)
 
 
 class MixemyRepositoryError(MixemyError):


### PR DESCRIPTION
This pull request includes several changes to the `src/mixemy/exceptions/__init__.py` file to modify how exceptions are initialized. The changes involve replacing the use of `super().__init__` with direct calls to the base class `__init__` methods.

Changes to exception initialization:

* [`src/mixemy/exceptions/__init__.py`](diffhunk://#diff-1101cabb592f1d4f323955d833123670e5d910f4f882ee4ed742de2cd9deca75L42-R42): Replaced `super().__init__(message)` with `Exception.__init__(self, message)` in the `MixemyError` class.
* [`src/mixemy/exceptions/__init__.py`](diffhunk://#diff-1101cabb592f1d4f323955d833123670e5d910f4f882ee4ed742de2cd9deca75L116-R116): Replaced `super().__init__(message)` with `MixemyError.__init__(self, message)` in the `MixemyConversionError` class.
* [`src/mixemy/exceptions/__init__.py`](diffhunk://#diff-1101cabb592f1d4f323955d833123670e5d910f4f882ee4ed742de2cd9deca75L149-R149): Replaced `super().__init__(message)` with `MixemyError.__init__(self, message)` in the `MixemyServiceError` class.
* [`src/mixemy/exceptions/__init__.py`](diffhunk://#diff-1101cabb592f1d4f323955d833123670e5d910f4f882ee4ed742de2cd9deca75L185-R185): Replaced `super().__init__(message=message)` with `MixemyError.__init__(self, message)` in the `MixemySetupError` class.