### PR TITLE
feat: Better recursive model naming and errors

### DIFF
--- a/src/mixemy/services/_asyncio.py
+++ b/src/mixemy/services/_asyncio.py
@@ -29,6 +29,10 @@ class BaseAsyncService(
     Attributes:
         repository_type (type[RepositoryAsyncT]): The type of the repository.
         output_schema_type (type[OutputSchemaT]): The type of the output schema.
+        default_recursive_model_conversion (bool): Default value for recursive model conversion.
+        default_exclude_unset (bool): Default value for excluding unset fields.
+        default_exclude (set[str] | None): Default value for excluded fields.
+        default_by_alias (bool): Default value for using field aliases.
     Methods:
         __init__(db_session: AsyncSession) -> None:
             Initializes the service with the given database session.
@@ -53,10 +57,10 @@ class BaseAsyncService(
     repository_type: type[RepositoryAsyncT]
     output_schema_type: type[OutputSchemaT]
 
-    default_model_recursive_model_conversion: bool = False
-    default_schema_exclude_unset: bool = True
-    default_schema_exclude: set[str] | None = None
-    default_schema_by_alias: bool = True
+    default_recursive_model_conversion: bool = False
+    default_exclude_unset: bool = True
+    default_exclude: set[str] | None = None
+    default_by_alias: bool = True
 
     def __init__(
         self,
@@ -75,26 +79,22 @@ class BaseAsyncService(
         self.recursive_model_conversion = (
             recursive_model_conversion
             if recursive_model_conversion is not None
-            else self.default_model_recursive_model_conversion
+            else self.default_recursive_model_conversion
         )
         self.exclude_unset = (
-            exclude_unset
-            if exclude_unset is not None
-            else self.default_schema_exclude_unset
+            exclude_unset if exclude_unset is not None else self.default_exclude_unset
         )
-        self.exclude = exclude if exclude is not None else self.default_schema_exclude
-        self.by_alias = (
-            by_alias if by_alias is not None else self.default_schema_by_alias
-        )
+        self.exclude = exclude if exclude is not None else self.default_exclude
+        self.by_alias = by_alias if by_alias is not None else self.default_by_alias
 
     async def create(
         self,
         object_in: InputSchema,
         *,
         recursive_model_conversion: bool | None = None,
-        schema_exclude_unset: bool | None = None,
-        schema_exclude: set[str] | None = None,
-        schema_by_alias: bool | None = None,
+        exclude_unset: bool | None = None,
+        exclude: set[str] | None = None,
+        by_alias: bool | None = None,
         **kwargs: Any,
     ) -> OutputSchemaT:
         return self.to_schema(
@@ -103,9 +103,9 @@ class BaseAsyncService(
                 db_object=self.to_model(
                     schema=object_in,
                     recursive_model_conversion=recursive_model_conversion,
-                    by_alias=schema_by_alias,
-                    exclude_unset=schema_exclude_unset,
-                    exclude=schema_exclude,
+                    by_alias=by_alias,
+                    exclude_unset=exclude_unset,
+                    exclude=exclude,
                 ),
                 **kwargs,
             ),

--- a/src/mixemy/services/_sync.py
+++ b/src/mixemy/services/_sync.py
@@ -29,6 +29,10 @@ class BaseSyncService(
     Attributes:
         repository_type (type[RepositorySyncT]): The type of the repository.
         output_schema_type (type[OutputSchemaT]): The type of the output schema.
+        default_recursive_model_conversion (bool): Default value for recursive model conversion.
+        default_exclude_unset (bool): Default value for excluding unset fields.
+        default_exclude (set[str] | None): Default value for excluded fields.
+        default_by_alias (bool): Default value for using field aliases.
     Methods:
         __init__(db_session: Session) -> None:
             Initializes the service with the given database session.
@@ -53,10 +57,10 @@ class BaseSyncService(
     repository_type: type[RepositorySyncT]
     output_schema_type: type[OutputSchemaT]
 
-    default_model_recursive_model_conversion: bool = False
-    default_schema_exclude_unset: bool = True
-    default_schema_exclude: set[str] | None = None
-    default_schema_by_alias: bool = True
+    default_recursive_model_conversion: bool = False
+    default_exclude_unset: bool = True
+    default_exclude: set[str] | None = None
+    default_by_alias: bool = True
 
     def __init__(
         self,
@@ -75,26 +79,22 @@ class BaseSyncService(
         self.recursive_model_conversion = (
             recursive_model_conversion
             if recursive_model_conversion is not None
-            else self.default_model_recursive_model_conversion
+            else self.default_recursive_model_conversion
         )
         self.exclude_unset = (
-            exclude_unset
-            if exclude_unset is not None
-            else self.default_schema_exclude_unset
+            exclude_unset if exclude_unset is not None else self.default_exclude_unset
         )
-        self.exclude = exclude if exclude is not None else self.default_schema_exclude
-        self.by_alias = (
-            by_alias if by_alias is not None else self.default_schema_by_alias
-        )
+        self.exclude = exclude if exclude is not None else self.default_exclude
+        self.by_alias = by_alias if by_alias is not None else self.default_by_alias
 
     def create(
         self,
         object_in: InputSchema,
         *,
         recursive_model_conversion: bool | None = None,
-        schema_exclude_unset: bool | None = None,
-        schema_exclude: set[str] | None = None,
-        schema_by_alias: bool | None = None,
+        exclude_unset: bool | None = None,
+        exclude: set[str] | None = None,
+        by_alias: bool | None = None,
         **kwargs: Any,
     ) -> OutputSchemaT:
         return self.to_schema(
@@ -103,9 +103,9 @@ class BaseSyncService(
                 db_object=self.to_model(
                     schema=object_in,
                     recursive_model_conversion=recursive_model_conversion,
-                    by_alias=schema_by_alias,
-                    exclude_unset=schema_exclude_unset,
-                    exclude=schema_exclude,
+                    by_alias=by_alias,
+                    exclude_unset=exclude_unset,
+                    exclude=exclude,
                 ),
                 **kwargs,
             ),

--- a/src/mixemy/utils/_convertors.py
+++ b/src/mixemy/utils/_convertors.py
@@ -72,9 +72,18 @@ def to_model(
 
     try:
         return model(**unpacked_schema, **sub_models)
+    except AttributeError as ex:
+        message = (
+            f"Error converting {type(schema)} to {model}.\nThis is likely as there is a nested model in {type(schema)} and `recursive_conversion` is false"
+            if not recursive_conversion
+            else None
+        )
+        raise MixemyConversionError(
+            model=model, schema=type(schema), is_model_to_schema=False, message=message
+        ) from ex
     except ArgumentError as ex:
         raise MixemyConversionError(
-            model=model, schema=schema, is_model_to_schema=False
+            model=model, schema=type(schema), is_model_to_schema=False
         ) from ex
 
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -165,7 +165,7 @@ def test_recursive_model(
     ):
         repository_type = ItemRepository
         output_schema_type = ItemOutput
-        default_model_recursive_model_conversion = True
+        default_recursive_model_conversion = True
 
     item_service = ItemService(db_session=session)
 


### PR DESCRIPTION
This pull request refactors the naming conventions for default schema-related attributes in both asynchronous and synchronous service classes, improves error handling in the `to_model` utility function, and updates test cases accordingly.

### Refactoring of default schema-related attributes:

* `src/mixemy/services/_asyncio.py`:
  - Renamed attributes in `BaseAsyncService` to remove the `schema_` prefix for consistency and clarity (e.g., `default_model_recursive_model_conversion` → `default_recursive_model_conversion`). [[1]](diffhunk://#diff-0b907da48e3f32e5bb5c71df6b1ead7b7d00f8810866b07fb7afe4c1573ae69cR32-R35) [[2]](diffhunk://#diff-0b907da48e3f32e5bb5c71df6b1ead7b7d00f8810866b07fb7afe4c1573ae69cL56-R63)
  - Updated the `__init__` method and `async def create` method to reflect the new attribute names. [[1]](diffhunk://#diff-0b907da48e3f32e5bb5c71df6b1ead7b7d00f8810866b07fb7afe4c1573ae69cL78-R97) [[2]](diffhunk://#diff-0b907da48e3f32e5bb5c71df6b1ead7b7d00f8810866b07fb7afe4c1573ae69cL106-R108)

* `src/mixemy/services/_sync.py`:
  - Similar renaming applied to `BaseSyncService` (e.g., `default_schema_exclude_unset` → `default_exclude_unset`). [[1]](diffhunk://#diff-b8599b6c8551559fb994145277f14ee4b24868d9997a2fe8a688d8ba34672c35R32-R35) [[2]](diffhunk://#diff-b8599b6c8551559fb994145277f14ee4b24868d9997a2fe8a688d8ba34672c35L56-R63)
  - Adjusted the `__init__` method and `def create` method to align with the updated attribute names. [[1]](diffhunk://#diff-b8599b6c8551559fb994145277f14ee4b24868d9997a2fe8a688d8ba34672c35L78-R97) [[2]](diffhunk://#diff-b8599b6c8551559fb994145277f14ee4b24868d9997a2fe8a688d8ba34672c35L106-R108)

### Error handling improvements:

* `src/mixemy/utils/_convertors.py`:
  - Enhanced error handling in the `to_model` function by adding a specific error message for `AttributeError` when `recursive_conversion` is disabled, and updated the exception type to `MixemyConversionError`.

### Test case updates:

* `tests/test_sync.py`:
  - Updated the `ItemService` test class to use the new attribute name `default_recursive_model_conversion`.