### PR TITLE
fix: Add read only to permission objects

### DIFF
--- a/src/mixemy/repositories/_asyncio.py
+++ b/src/mixemy/repositories/_asyncio.py
@@ -992,6 +992,7 @@ class PermissionAsyncRepository(BaseAsyncRepository[BaseModelT], ABC):
         auto_expunge: bool | None = None,
         auto_refresh: bool | None = None,
         with_for_update: bool = True,
+        is_read_only: bool | None = None,
         raise_permission_error: bool | None = None,
     ) -> BaseModelT | None:
         db_object = await self._get(
@@ -1012,6 +1013,7 @@ class PermissionAsyncRepository(BaseAsyncRepository[BaseModelT], ABC):
             auto_commit=auto_commit,
             auto_expunge=auto_expunge,
             auto_refresh=auto_refresh,
+            is_read_only=is_read_only,
             raise_permission_error=raise_permission_error,
         )
 
@@ -1056,6 +1058,7 @@ class PermissionAsyncRepository(BaseAsyncRepository[BaseModelT], ABC):
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
         with_for_update: bool = False,
+        is_read_only: bool | None = None,
         raise_permission_error: bool | None = None,
     ) -> None:
         db_object = await self._get(
@@ -1074,6 +1077,7 @@ class PermissionAsyncRepository(BaseAsyncRepository[BaseModelT], ABC):
             user_id=user_id,
             auto_commit=auto_commit,
             auto_expunge=auto_expunge,
+            is_read_only=is_read_only,
             raise_permission_error=raise_permission_error,
         )
 

--- a/src/mixemy/repositories/_sync.py
+++ b/src/mixemy/repositories/_sync.py
@@ -992,6 +992,7 @@ class PermissionSyncRepository(BaseSyncRepository[BaseModelT], ABC):
         auto_expunge: bool | None = None,
         auto_refresh: bool | None = None,
         with_for_update: bool = True,
+        is_read_only: bool | None = None,
         raise_permission_error: bool | None = None,
     ) -> BaseModelT | None:
         db_object = self._get(
@@ -1012,6 +1013,7 @@ class PermissionSyncRepository(BaseSyncRepository[BaseModelT], ABC):
             auto_commit=auto_commit,
             auto_expunge=auto_expunge,
             auto_refresh=auto_refresh,
+            is_read_only=is_read_only,
             raise_permission_error=raise_permission_error,
         )
 
@@ -1056,6 +1058,7 @@ class PermissionSyncRepository(BaseSyncRepository[BaseModelT], ABC):
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
         with_for_update: bool = False,
+        is_read_only: bool | None = None,
         raise_permission_error: bool | None = None,
     ) -> None:
         db_object = self._get(
@@ -1074,6 +1077,7 @@ class PermissionSyncRepository(BaseSyncRepository[BaseModelT], ABC):
             user_id=user_id,
             auto_commit=auto_commit,
             auto_expunge=auto_expunge,
+            is_read_only=is_read_only,
             raise_permission_error=raise_permission_error,
         )
 


### PR DESCRIPTION
This pull request introduces a new `is_read_only` parameter to both asynchronous and synchronous repository methods in `src/mixemy/repositories/_asyncio.py` and `src/mixemy/repositories/_sync.py`. This parameter allows for more granular control over operations by specifying whether the operation should be treated as read-only.

### Key Changes:

#### Asynchronous Repository Methods (`_asyncio.py`):
* Added the `is_read_only` parameter to the `update_with_permission` method and passed it to the `_get` method call. [[1]](diffhunk://#diff-77c838946f87e6af40e19e71520fc9d3b9796da3a58114853d7d88aac83818a1R995) [[2]](diffhunk://#diff-77c838946f87e6af40e19e71520fc9d3b9796da3a58114853d7d88aac83818a1R1016)
* Added the `is_read_only` parameter to the `delete_with_permission` method and passed it to the `_get` method call. [[1]](diffhunk://#diff-77c838946f87e6af40e19e71520fc9d3b9796da3a58114853d7d88aac83818a1R1061) [[2]](diffhunk://#diff-77c838946f87e6af40e19e71520fc9d3b9796da3a58114853d7d88aac83818a1R1080)

#### Synchronous Repository Methods (`_sync.py`):
* Added the `is_read_only` parameter to the `update_with_permission` method and passed it to the `_get` method call. [[1]](diffhunk://#diff-3c3ad752b6b63d7b036c90a4dc411805af166e36f9d89d291f293ec5beb7c916R995) [[2]](diffhunk://#diff-3c3ad752b6b63d7b036c90a4dc411805af166e36f9d89d291f293ec5beb7c916R1016)
* Added the `is_read_only` parameter to the `delete_with_permission` method and passed it to the `_get` method call. [[1]](diffhunk://#diff-3c3ad752b6b63d7b036c90a4dc411805af166e36f9d89d291f293ec5beb7c916R1061) [[2]](diffhunk://#diff-3c3ad752b6b63d7b036c90a4dc411805af166e36f9d89d291f293ec5beb7c916R1080)