### PR TITLE
feat: Add permission strategies

### DIFF
--- a/src/mixemy/repositories/_asyncio.py
+++ b/src/mixemy/repositories/_asyncio.py
@@ -13,7 +13,6 @@ from sqlalchemy import (
     func,
     select,
 )
-from sqlalchemy.orm import InstrumentedAttribute
 from sqlalchemy.orm.strategy_options import (
     _AbstractLoad,  # pyright: ignore[reportPrivateUsage]
 )
@@ -24,9 +23,10 @@ from mixemy.exceptions import (
     MixemyRepositoryReadOnlyError,
     MixemyRepositorySetupError,
 )
+from mixemy.repositories.permission_strategies import PermissionStrategyFactory
 from mixemy.schemas import InputSchema
 from mixemy.schemas.paginations import PaginationFields, PaginationFilter
-from mixemy.types import BaseModelT, SelectT
+from mixemy.types import BaseModelT, SelectT, permission_strategies
 from mixemy.utils import unpack_schema
 
 if TYPE_CHECKING:
@@ -862,8 +862,8 @@ class PermissionAsyncRepository(BaseAsyncRepository[BaseModelT], ABC):
     """PermissionAsyncRepository is an abstract base class that provides asynchronous methods for handling database operations with user permission checks.
 
     Attributes:
-        user_id_attribute (str | InstrumentedAttribute[Any]): The attribute representing the user ID.
-        user_joined_table (str | InstrumentedAttribute[Any] | None): The attribute representing the joined table for user permissions.
+        user_id_attribute (str): The attribute representing the user ID.
+        user_joined_table (str | None): The attribute representing the joined table for user permissions.
         default_raise_permission_error (bool): Default flag to raise permission error.
     Methods:
         __init__(self, *, loader_options: tuple[_AbstractLoad] | None = None, execution_options: dict[str, Any] | None = None, auto_expunge: bool | None = False, auto_refresh: bool | None = True, auto_commit: bool | None = False, raise_permission_error: bool | None = True) -> None:
@@ -890,10 +890,11 @@ class PermissionAsyncRepository(BaseAsyncRepository[BaseModelT], ABC):
             Verifies the initialization of the repository.
     """
 
-    user_id_attribute: str | InstrumentedAttribute[Any] = "user_id"
-    user_joined_table: str | InstrumentedAttribute[Any] | None = None
+    user_id_attribute: str = "user_id"
+    user_joined_table: str | None = None
 
     default_raise_permission_error: bool = True
+    default_permission_strategy: permission_strategies = "strict"
 
     def __init__(
         self,
@@ -905,6 +906,7 @@ class PermissionAsyncRepository(BaseAsyncRepository[BaseModelT], ABC):
         auto_commit: bool | None = None,
         is_read_only: bool | None = None,
         raise_permission_error: bool | None = None,
+        permission_strategy: permission_strategies | None = None,
     ) -> None:
         self.raise_permission_error = (
             raise_permission_error
@@ -918,6 +920,16 @@ class PermissionAsyncRepository(BaseAsyncRepository[BaseModelT], ABC):
             auto_refresh=auto_refresh,
             auto_commit=auto_commit,
             is_read_only=is_read_only,
+        )
+        self.permission_strategy = PermissionStrategyFactory.create_permission_strategy(
+            strategy=(
+                permission_strategy
+                if permission_strategy is not None
+                else self.default_permission_strategy
+            ),
+            model=self.model,
+            user_id_attribute=self.user_id_attribute,
+            user_joined_table=self.user_joined_table,
         )
 
     async def read_with_permission(
@@ -1136,17 +1148,10 @@ class PermissionAsyncRepository(BaseAsyncRepository[BaseModelT], ABC):
         statement: Select[SelectT],
         user_id: Any,
     ) -> Select[SelectT]:
-        if self.user_joined_table is None:
-            statement = statement.where(
-                getattr(self.model, self.user_id_attribute) == user_id
-            )
-        else:
-            joined_table = getattr(self.model, self.user_joined_table)
-            statement = statement.join(joined_table).where(
-                getattr(joined_table, self.user_id_attribute) == user_id
-            )
-
-        return statement
+        return self.permission_strategy.add_permission_filter(
+            statement=statement,
+            user_id=user_id,
+        )
 
     def handle_permission_on_db_oject(
         self,
@@ -1159,29 +1164,24 @@ class PermissionAsyncRepository(BaseAsyncRepository[BaseModelT], ABC):
         If the user does not have permission, it raises a MixemyRepositoryPermissionError or return false.
         If the user has permission, it returns true.
         """
-        if db_object is None:
+        authenticated, object_id = (
+            self.permission_strategy.check_permission_on_db_oject(
+                db_object=db_object,
+                user_id=user_id,
+            )
+        )
+
+        if authenticated:
             return True
 
-        if (
-            self.user_joined_table is None
-            and getattr(db_object, self.user_id_attribute) != user_id
-        ) or (
-            self.user_joined_table is not None
-            and getattr(
-                getattr(db_object, self.user_joined_table), self.user_id_attribute
-            )
-            != user_id
+        if raise_permission_error is False or (
+            raise_permission_error is None and self.raise_permission_error is False
         ):
-            if raise_permission_error is True or (
-                raise_permission_error is None and self.raise_permission_error
-            ):
-                raise MixemyRepositoryPermissionError(
-                    repository=self, object_id=id, user_id=user_id
-                )
-
             return False
 
-        return True
+        raise MixemyRepositoryPermissionError(
+            repository=self, object_id=object_id, user_id=user_id
+        )
 
     def _verify_init(self) -> None:
         for field in ["model", "user_id_attribute"]:

--- a/src/mixemy/repositories/permission_strategies/__init__.py
+++ b/src/mixemy/repositories/permission_strategies/__init__.py
@@ -1,0 +1,7 @@
+"""Strategies for permission management."""
+
+from ._factory import PermissionStrategyFactory
+
+__all__ = [
+    "PermissionStrategyFactory",
+]

--- a/src/mixemy/repositories/permission_strategies/_base.py
+++ b/src/mixemy/repositories/permission_strategies/_base.py
@@ -1,0 +1,32 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+from sqlalchemy import Select
+
+from mixemy.types import BaseModelT, SelectT
+
+
+class PermissionStrategy(ABC):
+    def __init__(
+        self,
+        model: type[BaseModelT],
+        user_id_attribute: str,
+        user_joined_table: str | None,
+    ) -> None:
+        self.model = model
+        self.user_id_attribute = user_id_attribute
+        self.user_joined_table = user_joined_table
+
+    @abstractmethod
+    def add_permission_filter(
+        self,
+        statement: Select[SelectT],
+        user_id: Any,
+    ) -> Select[SelectT]: ...
+
+    @abstractmethod
+    def check_permission_on_db_oject(
+        self,
+        db_object: BaseModelT | None,  # type: ignore no
+        user_id: Any,
+    ) -> tuple[bool, Any]: ...

--- a/src/mixemy/repositories/permission_strategies/_factory.py
+++ b/src/mixemy/repositories/permission_strategies/_factory.py
@@ -1,0 +1,33 @@
+from mixemy.repositories.permission_strategies._base import PermissionStrategy
+from mixemy.repositories.permission_strategies._loose_strategy import (
+    LoosePermissionStrategy,
+)
+from mixemy.repositories.permission_strategies._strict_strategy import (
+    StrictPermissionStrategy,
+)
+from mixemy.types import BaseModelT, permission_strategies
+
+
+class PermissionStrategyFactory:
+    """Factory class for creating permission strategies."""
+
+    @staticmethod
+    def create_permission_strategy(
+        strategy: permission_strategies,
+        model: type[BaseModelT],
+        user_id_attribute: str,
+        user_joined_table: str | None,
+    ) -> PermissionStrategy:
+        """Create a permission strategy based on the given strategy name."""
+        if strategy == "loose":
+            return LoosePermissionStrategy(
+                model=model,
+                user_id_attribute=user_id_attribute,
+                user_joined_table=user_joined_table,
+            )
+
+        return StrictPermissionStrategy(
+            model=model,
+            user_id_attribute=user_id_attribute,
+            user_joined_table=user_joined_table,
+        )

--- a/src/mixemy/repositories/permission_strategies/_loose_strategy.py
+++ b/src/mixemy/repositories/permission_strategies/_loose_strategy.py
@@ -1,0 +1,56 @@
+from typing import Any, override
+
+from sqlalchemy import Select, or_
+
+from mixemy.repositories.permission_strategies._base import PermissionStrategy
+from mixemy.types import BaseModelT, SelectT
+
+
+class LoosePermissionStrategy(PermissionStrategy):
+    @override
+    def add_permission_filter(
+        self,
+        statement: Select[SelectT],
+        user_id: Any,
+    ) -> Select[SelectT]:
+        if user_id is None:
+            return statement
+
+        if self.user_joined_table is None:
+            statement = statement.where(
+                or_(
+                    getattr(self.model, self.user_id_attribute) == None,  # noqa: E711
+                    getattr(self.model, self.user_id_attribute) == user_id,
+                )
+            )
+        else:
+            joined_table = getattr(self.model, self.user_joined_table)
+            statement = statement.join(joined_table, isouter=True).where(
+                getattr(joined_table, self.user_id_attribute) == user_id
+            )
+
+        return statement
+
+    @override
+    def check_permission_on_db_oject(
+        self,
+        db_object: BaseModelT | None,  # type: ignore no
+        user_id: Any,
+    ) -> tuple[bool, Any]:
+        """Check if the user has permission on the database object.
+
+        If the user does not have permission, it raises a MixemyRepositoryPermissionError or return false.
+        If the user has permission, it returns true.
+        """
+        if db_object is None or user_id is None:
+            return True, None
+
+        object_id = (
+            getattr(db_object, self.user_id_attribute)
+            if self.user_joined_table is None
+            else getattr(
+                getattr(db_object, self.user_joined_table), self.user_id_attribute
+            )
+        )
+
+        return (object_id is None) or (user_id == object_id), object_id

--- a/src/mixemy/repositories/permission_strategies/_loose_strategy.py
+++ b/src/mixemy/repositories/permission_strategies/_loose_strategy.py
@@ -37,11 +37,6 @@ class LoosePermissionStrategy(PermissionStrategy):
         db_object: BaseModelT | None,  # type: ignore no
         user_id: Any,
     ) -> tuple[bool, Any]:
-        """Check if the user has permission on the database object.
-
-        If the user does not have permission, it raises a MixemyRepositoryPermissionError or return false.
-        If the user has permission, it returns true.
-        """
         if db_object is None or user_id is None:
             return True, None
 

--- a/src/mixemy/repositories/permission_strategies/_strict_strategy.py
+++ b/src/mixemy/repositories/permission_strategies/_strict_strategy.py
@@ -1,0 +1,45 @@
+from typing import Any, override
+
+from sqlalchemy import Select
+
+from mixemy.repositories.permission_strategies._base import PermissionStrategy
+from mixemy.types import BaseModelT, SelectT
+
+
+class StrictPermissionStrategy(PermissionStrategy):
+    @override
+    def add_permission_filter(
+        self,
+        statement: Select[SelectT],
+        user_id: Any,
+    ) -> Select[SelectT]:
+        if self.user_joined_table is None:
+            statement = statement.where(
+                getattr(self.model, self.user_id_attribute) == user_id
+            )
+        else:
+            joined_table = getattr(self.model, self.user_joined_table)
+            statement = statement.join(joined_table).where(
+                getattr(joined_table, self.user_id_attribute) == user_id
+            )
+
+        return statement
+
+    @override
+    def check_permission_on_db_oject(
+        self,
+        db_object: BaseModelT | None,  # type: ignore no
+        user_id: Any,
+    ) -> tuple[bool, Any]:
+        if db_object is None:
+            return True, None
+
+        object_id = (
+            getattr(db_object, self.user_id_attribute)
+            if self.user_joined_table is None
+            else getattr(
+                getattr(db_object, self.user_joined_table), self.user_id_attribute
+            )
+        )
+
+        return user_id == object_id, object_id

--- a/src/mixemy/types/__init__.py
+++ b/src/mixemy/types/__init__.py
@@ -21,7 +21,7 @@ Exports:
 """
 
 from ._models import BaseModelT
-from ._repositories import SelectT
+from ._repositories import SelectT, permission_strategies
 from ._schemas import (
     BaseSchemaT,
     CreateSchemaT,
@@ -48,4 +48,5 @@ __all__ = [
     "RepositorySyncT",
     "SelectT",
     "UpdateSchemaT",
+    "permission_strategies",
 ]

--- a/src/mixemy/types/_repositories.py
+++ b/src/mixemy/types/_repositories.py
@@ -1,3 +1,4 @@
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar
 
 SelectT = TypeVar("SelectT", bound=tuple[Any, ...])
+permission_strategies = Literal["loose", "strict"]


### PR DESCRIPTION
This pull request introduces a new permission strategy framework for both synchronous and asynchronous repositories, enhancing flexibility and modularity in handling user permissions. The changes include the creation of a strategy-based permission system, updates to repository classes to integrate the new framework, and the addition of two predefined strategies: "strict" and "loose."

### Permission Strategy Framework

* Added a `PermissionStrategy` abstract base class in `src/mixemy/repositories/permission_strategies/_base.py` to define the interface for permission strategies, including methods for filtering queries and checking permissions on database objects.
* Introduced a `PermissionStrategyFactory` in `src/mixemy/repositories/permission_strategies/_factory.py` to dynamically create strategies based on a given type ("strict" or "loose").
* Added two concrete implementations:
  - `StrictPermissionStrategy` for strict permission checks, ensuring the user ID matches exactly.
  - `LoosePermissionStrategy` for more lenient checks, allowing null values or outer joins.

### Repository Updates

* Updated `PermissionAsyncRepository` and `PermissionSyncRepository` in `src/mixemy/repositories/_asyncio.py` and `src/mixemy/repositories/_sync.py`, respectively, to integrate the new permission strategy framework:
  - Replaced `user_id_attribute` and `user_joined_table` types to simplify them to `str` and `str | None`. [[1]](diffhunk://#diff-77c838946f87e6af40e19e71520fc9d3b9796da3a58114853d7d88aac83818a1L865-R866) [[2]](diffhunk://#diff-3c3ad752b6b63d7b036c90a4dc411805af166e36f9d89d291f293ec5beb7c916L865-R866)
  - Added a `default_permission_strategy` attribute and a `permission_strategy` parameter to the constructor. [[1]](diffhunk://#diff-77c838946f87e6af40e19e71520fc9d3b9796da3a58114853d7d88aac83818a1L893-R897) [[2]](diffhunk://#diff-3c3ad752b6b63d7b036c90a4dc411805af166e36f9d89d291f293ec5beb7c916L893-R897) [[3]](diffhunk://#diff-77c838946f87e6af40e19e71520fc9d3b9796da3a58114853d7d88aac83818a1R909) [[4]](diffhunk://#diff-3c3ad752b6b63d7b036c90a4dc411805af166e36f9d89d291f293ec5beb7c916R909)
  - Refactored methods like `add_permission_filter` and `handle_permission_on_db_oject` to delegate behavior to the strategy instance. [[1]](diffhunk://#diff-77c838946f87e6af40e19e71520fc9d3b9796da3a58114853d7d88aac83818a1L1139-L1150) [[2]](diffhunk://#diff-3c3ad752b6b63d7b036c90a4dc411805af166e36f9d89d291f293ec5beb7c916L1139-L1150) [[3]](diffhunk://#diff-77c838946f87e6af40e19e71520fc9d3b9796da3a58114853d7d88aac83818a1L1162-R1184) [[4]](diffhunk://#diff-3c3ad752b6b63d7b036c90a4dc411805af166e36f9d89d291f293ec5beb7c916L1162-R1184)

### Type System Enhancements

* Added a new `permission_strategies` type as a `Literal["loose", "strict"]` in `src/mixemy/types/_repositories.py` and exposed it in `src/mixemy/types/__init__.py`. [[1]](diffhunk://#diff-65c0c69d5132398c6eda47ba25822b37d232a63ae66c403dd280d9cf3e7e88f6L1-R4) [[2]](diffhunk://#diff-45da135557f7d4728eb5ebce1d55a763367baba5b4c27f373093022045bc2891L24-R24) [[3]](diffhunk://#diff-45da135557f7d4728eb5ebce1d55a763367baba5b4c27f373093022045bc2891R51)

### Code Organization

* Introduced a new `permission_strategies` module in `src/mixemy/repositories/` to house the strategy-related classes and factory.

These changes improve the modularity and maintainability of permission handling in the repository layer, allowing for future extensions and custom strategies.